### PR TITLE
feat(compatibility)!: update .NET targets

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
         
     - name: Restore dependencies
       run: dotnet restore

--- a/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
+++ b/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Xyaneon.Games.Dice/Xyaneon.Games.Dice.csproj
+++ b/Xyaneon.Games.Dice/Xyaneon.Games.Dice.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Xyaneon.Games.Dice</PackageId>
     <PackageTags>netstandard games dice</PackageTags>
     <Description>


### PR DESCRIPTION
Switches the library to target .NET Standard 2.0 and the test project to .NET 6, instead of .NET 5 for both.

Fixes #6, fixes #7.