### PR TITLE
bump(deps): update MSTest dependencies

### DIFF
--- a/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
+++ b/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 

--- a/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
+++ b/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Replaces Dependabot pull requests #15 and #19, since both upgrades need to be done simultaneously to pass.