### PR TITLE
fix(doc-comments): fix ambiguous reference warnings for XML doc comments

### DIFF
--- a/Xyaneon.Games.Dice/Coin.cs
+++ b/Xyaneon.Games.Dice/Coin.cs
@@ -27,7 +27,7 @@ namespace Xyaneon.Games.Dice
         public Coin(int seed) : base(Sides, seed) { }
 
         /// <summary>
-        /// An alias for the inherited <see cref="Die{TFace}.Roll"/> method
+        /// An alias for the inherited <see cref="Die{TFace}.Roll()"/> method
         /// specific to coins.
         /// </summary>
         /// <returns>A new <see cref="CoinFlipResult"/> value.</returns>
@@ -43,7 +43,7 @@ namespace Xyaneon.Games.Dice
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="times"/> is less than one.
         /// </exception>
-        /// <seealso cref="Flip"/>
+        /// <seealso cref="Flip()"/>
         public IEnumerable<CoinFlipResult> Flip(int times) => Roll(times);
     }
 }

--- a/Xyaneon.Games.Dice/Die.cs
+++ b/Xyaneon.Games.Dice/Die.cs
@@ -60,7 +60,7 @@ namespace Xyaneon.Games.Dice
         /// </exception>
         /// <remarks>
         /// If a seed is provided to the constructor, then the result of each
-        /// <see cref="Roll"/> call made in sequence will be predetermined by
+        /// <see cref="Roll()"/> call made in sequence will be predetermined by
         /// the seed value provided.
         /// </remarks>
         /// <seealso cref="Die{TFace}.Die(IEnumerable{TFace})"/>
@@ -97,7 +97,7 @@ namespace Xyaneon.Games.Dice
         /// <returns>The result of the die roll as a <typeparamref name="TFace"/> value.</returns>
         /// <remarks>
         /// If a seed was provided to the constructor, then the result of each
-        /// <see cref="Roll"/> call made in sequence will be predetermined by
+        /// <see cref="Roll()"/> call made in sequence will be predetermined by
         /// the seed value provided.
         /// </remarks>
         /// <seealso cref="Roll(int)"/>
@@ -115,7 +115,7 @@ namespace Xyaneon.Games.Dice
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="times"/> is less than one.
         /// </exception>
-        /// <seealso cref="Roll"/>
+        /// <seealso cref="Roll()"/>
         public IEnumerable<TFace> Roll(int times)
         {
             if (times < 1)


### PR DESCRIPTION
Fixes #25.