### PR TITLE
bump(deps): bump MSTest packages to 3.8.2

### DIFF
--- a/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
+++ b/Xyaneon.Games.Dice.Test/Xyaneon.Games.Dice.Test.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Combines and replaces #124 and #125.